### PR TITLE
[#253] 그림판 전체 삭제 안되는 오류

### DIFF
--- a/gridam/src/features/canvas/use-canvas-drawing.ts
+++ b/gridam/src/features/canvas/use-canvas-drawing.ts
@@ -48,7 +48,21 @@ export function useCanvasDrawing(initialImage?: string | null) {
   }, [saveCanvasImage])
 
   // clear
-  const clearHistory = () => setHistory([])
+  const clearHistory = () => {
+    const canvas = canvasRef.current
+    const ctx = ctxRef.current
+    // 준비 안된 상태 처리
+    if (!canvas || !ctx) {
+      setHistory([])
+      setCanvasImage(null)
+      return
+    }
+    // 초기화랑 동일한 로직 진행
+    ctx.clearRect(0, 0, canvas.width, canvas.height)
+    const emptySnap = ctx.getImageData(0, 0, canvas.width, canvas.height)
+    setHistory([emptySnap])
+    setCanvasImage(null)
+  }
 
   // css 색상 해석
   const resolveColor = useCallback((input: string): string => {


### PR DESCRIPTION
### 📋 관련 이슈
Fixes #253

### 🧩 작업 내용
fix(canvas): 전체 삭제 시 캔버스 초기화가 화면에 반영되지 않던 문제 수정
- clearHisotry가 history만 비우고 실제 캔버스를 초기화하지 않던 문제 해결
- clearRect()로 캔버스를 실제로 비우도록 처리
- 빈 캔버스 스냅샷을 History에 추가해 undo 동작도 정상화 처리
- setCanvasImage(null) 호출로 상위 상태에도 즉시 반영되도록 수정

### ✅ 테스트 결과
- [x] build
- [x] lint