### PR TITLE
[#267] 그림판 모바일 작성 어려움 개선

### DIFF
--- a/gridam/src/shared/ui/canvas/canvas-view.tsx
+++ b/gridam/src/shared/ui/canvas/canvas-view.tsx
@@ -20,14 +20,19 @@ export function CanvasView({
   className,
   height = 45,
 }: Props) {
+  const handleTouchMove = (e: React.PointerEvent<HTMLCanvasElement>) => {
+    e.preventDefault()
+    onPointerMove(e as any)
+  }
+
   return (
-    <div className="w-full border border-gray-200 rounded-xl bg-white shadow-sm">
+    <div className="w-full border border-gray-200 rounded-xl bg-white shadow-sm overflow-hidden">
       <canvas
         ref={canvasRef}
-        className={cn('block w-full rounded-xl cursor-crosshair', className)}
-        style={{ height: `${height}vh` }}
+        className={cn('block w-full rounded-xl cursor-crosshair touch-none', className)}
+        style={{ height: `${height}vh`, touchAction: 'none' }}
         onPointerDown={onPointerDown}
-        onPointerMove={onPointerMove}
+        onPointerMove={handleTouchMove}
         onPointerUp={onPointerUpOrLeave}
         onPointerLeave={onPointerUpOrLeave}
       />


### PR DESCRIPTION
### 📋 관련 이슈
Fixes #267 

### 🧩 작업 내용
1. 모바일 스크롤 간섭 제거 및 터치 드로잉 안정화
- canvas 요소에 touch-action: none 적용하여 기본 스크롤·제스처 차단
- touchmove 핸들러에서 preventDefault로 iOS Safari의 passive 이벤트 스크롤 방지
- 컨테이너 div에 overflow-hidden 추가해 의도치 않은 화면 스크롤 차단
- 모바일 환경에서도 드로잉 시 스크롤 개입 없이 안정적으로 그릴 수 있도록 개선

### ✅ 테스트 결과
- [x] build
- [x] lint
- [x] mobile