### PR TITLE
[#303] 수정시 이미지 이전 값 불러와짐

### DIFF
--- a/gridam/src/shared/ui/canvas/canvas-container.tsx
+++ b/gridam/src/shared/ui/canvas/canvas-container.tsx
@@ -7,7 +7,7 @@ import { useCanvasStore } from '@/store/canvas-store'
 import { memo } from 'react'
 
 function CanvasContainer({ initialImage }: { initialImage?: string | null }) {
-  const { setImage } = useCanvasStore()
+  const setImage = useCanvasStore((s) => s.setImage)
   const {
     canvasRef,
     canvasImage,


### PR DESCRIPTION
### 📋 관련 이슈
Fixes #303 

### 🧩 작업 내용
1. 캔버스 이미지 저장 시 이전 값 저장되는 문제 수정
- 일기 작성/수정 폼에서 캔버스 이미지 값을 `getState()`로 단발 조회하던 부분을 
- 저장 시점에 최신 이미지가 반영되도록 스토어 selector 구독 방식으로 변경( `useCanvasStore((s) => s.image)` 형태로 수정)

### 🧑 담당자
@OlMinJe 

### ✅ 테스트 결과
- [x] build
- [x] lint