### PR TITLE
[#289] URL 토큰 만료로 인한 캘린더 일기 이미지 로드 실패

### DIFF
--- a/gridam/src/app/apis/calendar/day/route.ts
+++ b/gridam/src/app/apis/calendar/day/route.ts
@@ -1,6 +1,8 @@
 import { MESSAGES } from '@/shared/constants/messages'
 import { getAuthenticatedUser } from '@/shared/utils/get-authenticated-user'
 import { NextRequest, NextResponse } from 'next/server'
+import { withSignedImageUrls } from '@/shared/utils/with-signed-image-urls'
+import type { Diary } from '@/features/feed/feed.type' // ✅ 타입 임포트
 
 export async function GET(req: NextRequest) {
   try {
@@ -38,8 +40,20 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ ok: false, message: MESSAGES.DIARY.ERROR.READ }, { status: 500 })
     }
 
-    const diary = diaryData?.length ? diaryData[0] : null
+    // 기본값은 null
+    let diary: Diary | null = null
 
+    // 2) 여기서 fresh signed URL 생성
+    if (diaryData && diaryData.length > 0) {
+      const [signedDiary] = await withSignedImageUrls<Diary>(
+        supabase,
+        diaryData as Diary[],
+        60 * 60 // 옵션: 1시간 TTL (안 넣으면 기본 5분)
+      )
+      diary = signedDiary
+    }
+
+    // 선택 날짜의 메모 조회
     const { data: memosData, error: memoError } = await supabase
       .from('memos')
       .select('*')


### PR DESCRIPTION
### 관련 이슈
- Fixes #289 

### 작업 내용
- withSignedImageUrls()를 활용하여 이미지 url 토큰 만료 방지 코드 추가

### 테스트 결과
- [x] lint
- [x] build

@OlMinJe 
