### PR TITLE
[#336] 그림일기 커서 크기 조정할때마다 번쩍거림

### DIFF
--- a/gridam/src/shared/hooks/use-canvas-drawing.ts
+++ b/gridam/src/shared/hooks/use-canvas-drawing.ts
@@ -15,7 +15,7 @@ export function useCanvasDrawing(initialImage?: string | null) {
   // 수정 시 기존 이미지를 배경으로 깔기 위한 ref
   const baseImgRef = useRef<HTMLImageElement | null>(null)
   const baseImgReadyRef = useRef(false)
- // history 각 스냅샷 시점의 strokes 길이
+  // history 각 스냅샷 시점의 strokes 길이
   const strokeCountsRef = useRef<number[]>([])
 
   // UI 상태
@@ -26,13 +26,6 @@ export function useCanvasDrawing(initialImage?: string | null) {
   // 스냅샷 기반 히스토리
   const [history, setHistory] = useState<ImageData[]>([])
   const maxHistory = 50
-
-  // size 변경 시 현재 context 선 두께 반영
-  useEffect(() => {
-    const ctx = ctxRef.current
-    if (!ctx) return
-    ctx.lineWidth = size
-  }, [size])
 
   const toggleEraser = () => setIsEraser((v) => !v)
 
@@ -54,7 +47,7 @@ export function useCanvasDrawing(initialImage?: string | null) {
     })
   }, [])
 
-   // 기존 이미지와 모든 스트로크를 현재 캔버스 크기에 맞게 재렌더
+  // 기존 이미지와 모든 스트로크를 현재 캔버스 크기에 맞게 재렌더
   const redrawAll = useCallback(() => {
     const canvas = canvasRef.current
     const ctx = ctxRef.current
@@ -148,7 +141,6 @@ export function useCanvasDrawing(initialImage?: string | null) {
     return { x: Math.max(0, Math.min(1, x)), y: Math.max(0, Math.min(1, y)) }
   }
 
-
   // 그림 그리기 시작
   const onPointerDown = useCallback(
     (e: React.PointerEvent<HTMLCanvasElement>) => {
@@ -228,10 +220,20 @@ export function useCanvasDrawing(initialImage?: string | null) {
     ctxRef.current = ctx
   }, [size])
 
-  // 초기 세팅 1번 캔버스 만들기
+  // size 변경 시 현재 context 선 두께 반영
   useEffect(() => {
-    setupCanvas()
+    const ctx = ctxRef.current
+    if (!ctx) return
+    ctx.lineWidth = size
+  }, [size])
 
+  // 초기 세팅 1번 캔버스 만들기
+  const didInitRef = useRef(false)
+  useEffect(() => {
+    if (didInitRef.current) return
+    didInitRef.current = true
+
+    setupCanvas()
     const canvas = canvasRef.current
     const ctx = ctxRef.current
     if (canvas && ctx) {

--- a/gridam/src/shared/ui/canvas/canvas-container.tsx
+++ b/gridam/src/shared/ui/canvas/canvas-container.tsx
@@ -10,7 +10,6 @@ function CanvasContainer({ initialImage }: { initialImage?: string | null }) {
   const setImage = useCanvasStore((s) => s.setImage)
   const {
     canvasRef,
-    canvasImage,
 
     color,
     setColor,
@@ -31,7 +30,7 @@ function CanvasContainer({ initialImage }: { initialImage?: string | null }) {
 
     const canvas = canvasRef.current
     if (canvas) {
-    setImage(canvas.toDataURL('image/png'))
+      setImage(canvas.toDataURL('image/png'))
     }
   }
 


### PR DESCRIPTION
### 📋 관련 이슈
Fixes #336 

### 🧩 작업 내용
1. size 변경 시 캔버스 재초기화 방지로 깜빡임 수정 
- 기존의 “setupCanvas 의존성 때문에 size 바뀔 때마다 초기화”되는 루프를 끊음

### 🧑 담당자
@OlMinJe 

### ✅ 테스트 결과
- [x] build
- [x] lint