### PR TITLE
[#342] 임시 저장 → 수정으로 들어오면 취소 버튼 안됨

### DIFF
--- a/gridam/src/features/diary/components/diary-cancel-button.tsx
+++ b/gridam/src/features/diary/components/diary-cancel-button.tsx
@@ -21,10 +21,12 @@ export default function DiaryCancelButton() {
             label={MESSAGES.COMMON.CANCEL}
           />
           <ClientButton
+            type="button"
             className="bg-black text-white px-3 py-2 rounded"
-            onClick={() => {
-              router.back()
+            onClick={(e) => {
+              e.preventDefault()
               close()
+              router.push('/draft')
             }}
             label={MESSAGES.COMMON.CONFIRM}
           />


### PR DESCRIPTION
### 📋 관련 이슈
Fixes #342

### 🧩 작업 내용
1. 임시 수정 페이지에서 취소 버튼 동작 안하는 오류 해결

### 🧑 담당자
@OlMinJe 

### ✅ 테스트 결과
- [x] build
- [x] lint