### PR TITLE
[#358, 359] 메모 작성 ux 개선

### DIFF
--- a/gridam/src/features/memo/components/markdown-editor.tsx
+++ b/gridam/src/features/memo/components/markdown-editor.tsx
@@ -35,6 +35,7 @@ export default function MarkdownEditor({ value, onChange }: Props) {
             ref={textareaRef}
             value={value}
             onChange={(e) => onChange(e.target.value)}
+            id="memo-content"
             className="
             flex-1 w-full resize-none
             bg-transparent px-4 py-3 text-sm text-foreground outline-none

--- a/gridam/src/features/memo/components/memo-editor-dialog.tsx
+++ b/gridam/src/features/memo/components/memo-editor-dialog.tsx
@@ -47,12 +47,15 @@ export default function MemoEditorDialog({ open, onOpenChange, initialMemo, onSu
     const formData = new FormData(event.currentTarget)
     const title = String(formData.get('title') ?? '').trim()
 
-    if (!title && !content.trim()) {
-      const msg = isEditMode
-        ? MESSAGES.MEMO.ERROR.UPDATE_NO_DATA
-        : MESSAGES.MEMO.ERROR.CREATE_NO_DATA
+    if (!title.trim()) {
+      toast.error('제목을 입력해주세요.')
+      document.getElementById('memo-title')?.focus()
+      return
+    }
 
-      toast.error(msg ?? '제목 또는 내용을 입력해주세요.')
+    if (!content.trim()) {
+      toast.error('내용을 입력해주세요.')
+      document.getElementById('memo-content')?.focus()
       return
     }
 
@@ -110,7 +113,7 @@ export default function MemoEditorDialog({ open, onOpenChange, initialMemo, onSu
       size="2xl"
       closeOnBackdrop
       closeOnEscape
-      className="bg-background w-full max-w-5xl"
+      className="bg-background w-full max-w-5xl overflow-auto"
     >
       <form onSubmit={handleSubmit} className="flex h-full flex-col">
         <ModalHeader className="flex items-center justify-between px-6 py-4">

--- a/gridam/src/features/memo/components/memo-editor-tag.tsx
+++ b/gridam/src/features/memo/components/memo-editor-tag.tsx
@@ -82,7 +82,7 @@ export default function MemoTagField({ tags, onChange }: MemoTagFieldProps) {
             <span>{tag}</span>
 
             <span
-              className="ml-2 rounded-full px-1 text-[10px]"
+              className="ml-2 rounded-full px-1 text-[10px] cursor-pointer"
               onClick={(e) => {
                 e.stopPropagation()
                 removeTag(tag)


### PR DESCRIPTION
## 작업 내용
- 메모 작성 모바일 대응
- 태그 삭제  x cursor-pointer 추가
- 제목, 내용 공백 시 토스트 문구 추가
- 저장하기 클릭 시 해당 필드로 포커싱