### PR TITLE
[#375] 소셜 로그인 url 버그

### DIFF
--- a/gridam/src/app/(auth)/callback/route.ts
+++ b/gridam/src/app/(auth)/callback/route.ts
@@ -8,7 +8,7 @@ export async function GET(request: NextRequest) {
 
   // code 없으면 로그인으로
   if (!code) {
-    return NextResponse.redirect(new URL('/login', request.url))
+    return NextResponse.redirect(new URL(`${URL_CONSTANTS.AUTH.LOGIN}`, request.url))
   }
 
   const supabase = await getSupabaseServer()
@@ -19,8 +19,8 @@ export async function GET(request: NextRequest) {
   if (error) {
     console.error('exchangeCodeForSession error', error)
     // 세션 교환 실패 -> 로그인으로
-    return NextResponse.redirect(new URL('/login', request.url))
+    return NextResponse.redirect(new URL(`${URL_CONSTANTS.AUTH.LOGIN}`, request.url))
   }
 
-  return NextResponse.redirect(new URL('/', request.url))
+  return NextResponse.redirect(new URL(`${URL_CONSTANTS.HOME}`, request.url))
 }


### PR DESCRIPTION
## 작업 내용
- `getOrigin`을 사용하지 않고 `new URL('/...', request.url)`로만 redirect 하도록 바꿈
- 로컬로 들어오면 로컬로
- 그리담으로 들어오면 그리담으로
